### PR TITLE
user_delete_confirm_add

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -169,3 +169,18 @@ a{
 .sales_amount {
 	font-size: 30px;
 }
+
+.delete_confirm_title{
+	font-size: 70px;
+}
+
+.delete_confirm_message{
+	text-align: center;
+	margin: 20px 20% 40px;
+}
+
+.delete_confirm_link{
+	margin-top: 25px;
+}
+
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,13 @@ class UsersController < ApplicationController
 
   def destroy
     user = User.find(params[:id])
-    user.destroy
-    redirect_to action: 'index'
+      if current_user.user_flag == 1
+        user.destroy
+        redirect_to action: 'index'
+      else
+        user.destroy
+        redirect_to '/'
+      end
   end
 
   def show
@@ -29,6 +34,9 @@ class UsersController < ApplicationController
   def edit
   	@user = User.find(params[:id])
   	@address = @user.addresses.first
+  end
+
+  def delete_confirmation
   end
 
   def update

--- a/app/views/users/delete_confirmation.html.erb
+++ b/app/views/users/delete_confirmation.html.erb
@@ -1,0 +1,20 @@
+<div class="delete_confirm_message">
+	<h1 class="delete_confirm_title">退会確認</h1><br>
+	<h5>退会手続きをされますと全てのサービスが<br>
+		ご利用頂けなくなります。再度ご利用頂くには、<br>
+		新規登録が必要となります。<br>
+	本当に退会してよろしいですか？</h5>
+	<div class="delete_confirm_link">
+		<button type="button">
+			<%= link_to "戻る", :back %>
+		</button>
+	</div>
+	<div class="delete_confirm_link">
+		<button type="button">
+			<%= link_to "退会する", user_path(current_user.id),  method: :delete, "data-confirm" => "本当に退会しますか？" %>
+		</button>
+	</div>
+
+</div>
+
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,7 +36,7 @@
 				<i class="far fa-heart"></i>
 				<span>お気に入りリスト</span>
 			<% end %>
-			<%= link_to "退会", edit_user_path, class: "btn btn-info" %>
+			<%= link_to "退会", "/delete_confirmation", class: "btn btn-info" %>
 		</div>
 	</div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "/users/:id/orders/confirmation/:id" => "orders#confirmation", as: 'confirmation'
   get "/order_items" => "order_items#index", as: 'index'
   get "/thankyou" => "order_items#thankyou", as: 'thankyou'
+  get "/delete_confirmation" => "users#delete_confirmation",as: 'delete_confirmation'
   root 'products#index'
   devise_for :users, controllers: {
     sessions: 'users/sessions',

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,14 +76,13 @@ ActiveRecord::Schema.define(version: 2019_05_23_044939) do
     t.integer "product_id"
     t.string "artist"
     t.integer "price"
-    t.string "lebel"
     t.integer "genre", default: 0
     t.integer "buy_status", default: 0
     t.integer "stocks"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "label"
-    t.text "image_id"
+    t.string "image_id"
     t.integer "disc_type"
     t.string "product_name"
     t.string "release_date"


### PR DESCRIPTION
ユーザー退会画面を新規作成（ルート、アクション、view）

削除後
管理者はユーザー一覧に
一般はtopページに遷移

ユーザー編集画面の退会リンクを同ページに変更
